### PR TITLE
add disqus feature

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,4 @@ baseurl = "http://cm.cecs.anu.edu.au/"
 languageCode = "en-us"
 title = "Computational Media Lab"
 canonifyurls = true
+disqusShortname = "avalanchesiqi"

--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,0 +1,17 @@
+<div id="disqus_thread"></div>
+<script type="text/javascript">
+
+(function() {
+    // Don't ever inject Disqus on localhost--it creates unwanted
+    // discussions from 'localhost:1313' on your Disqus account...
+    //if (window.location.hostname == "localhost")
+    //    return;
+
+    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+    var disqus_shortname = '{{ .Site.DisqusShortname }}';
+    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+})();
+</script>
+<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<a href="http://disqus.com/" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -30,6 +30,7 @@
             {{ partial "menu.html" . }}
         </div>
     </div>
+{{ partial "disqus.html" . }}
 {{ partial "footer.copyright.html" . }}
 </div>
 {{ partial "footer.html" . }}


### PR DESCRIPTION
Integrate disqus service into the post page.

Note: It requires a disqus account that speaks for the website, so far I use my personal disqus account to test. Once we register disqus with a group name (cmLab or something similar) we can replace the shortname in config.toml file.