### PR TITLE
Upgrade Hugo to v0.99.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 public/*
 .vscode
+.hugo_build.lock

--- a/config.toml
+++ b/config.toml
@@ -4,4 +4,7 @@ title = "Computational Media Lab"
 canonifyurls = true
 disqusShortname = "computationalmedia"
 [markup]
-  defaultMarkdownHandler = "blackfriday"
+  defaultMarkdownHandler = "goldmark"
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html lang="en">
+
 <head>
     {{ partial "meta.html" . }}
 
     <title>{{ .Title }} - {{ .Site.BaseURL }}</title>
     <link rel="canonical" href="{{ .Permalink }}">
     {{ partial "header.includes.html" . }}
-    {{ if .RSSLink }}<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />{{ end }}
 </head>

--- a/static/documents/publications.bib
+++ b/static/documents/publications.bib
@@ -155,10 +155,7 @@
 }
 
 @article{toyer2020asnets,
-  author    = {Sam Toyer and
-               Sylvie Thi{\'{e}}baux and
-               Felipe W. Trevizan and
-               Lexing Xie},
+  author    = {Sam Toyer and Sylvie Thi{\'{e}}baux and Felipe W. Trevizan and Lexing Xie},
   title     = {ASNets: Deep Learning for Generalised Planning},
   journal   = {J. Artif. Intell. Res.},
   volume    = {68},


### PR DESCRIPTION
Hugo did a great job on compatibility! There are only a few minor changes.

- `.hugo_build.lock` is a temporary lock file, hence ignored.
- `blackfriday` will be deprecated, hence change to `goldmark`
- `.RSSLink` has deprecated, removed because RSS is not used.
- `\n`, `\r` in field author will cause error in bibtex-js.